### PR TITLE
Removed wire from 'Installation' subsection of README #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Before starting development, make sure to install the following dependencies:
 - [Install Go](https://go.dev/doc/install)
 - [Install Hugo](https://gohugo.io/installation/)
 - [Install NPM and NodeJS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
-- [Install Wire](https://github.com/google/wire#installing)
 
 ### Installation
 


### PR DESCRIPTION
## Summary of Changes

This pull request removes the installation instruction for Wire dependency from the README.md file.

## Benefits and Impact

The removal of the Wire installation step indicates that the project no longer requires this dependency, making the setup process simpler for new contributors. This change may be the result of a recent update or refactoring that eliminated the need for Wire.

## Testing and Validation

Since this is a documentation change, no functional tests were necessary. The change has been visually inspected to ensure that the README.md file is formatted correctly.

## Screenshots or Examples

Not applicable for this change, as it only affects the documentation.

## Checklist

- [x] I have updated the relevant documentation, if necessary.
- [ ] I have added tests to cover my changes, if applicable.
- [x] All new and existing tests passed.
- [ ] My changes do not generate new warnings or errors.

## Additional Information

None.
