### PR TITLE
Added Hugo CLI commands to usage subsection of README #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Build all the services defined in the docker-compose.yml file. This command will
 docker-compose build
 ```
 
+### Build Hugo site
+
+Build the Hugo documentation site maintained in the `internal/docs` directory. This command will build the Hugo the documentation site for distribution, placing the output in the `internal/docs/public` directory.
+
+```shell
+hugo -s internal/docs    # exclude drafts
+```
+
+```shell
+hugo -s internal/docs -D # include drafts
+```
+
 ### Build NPM packages
 
 Compile and build all NPM packages in the monorepo, considering their interdependencies. The -ws flag ensures that the build is performed across all workspaces.
@@ -96,6 +108,18 @@ Execute all Go tests in the repository, including unit and integration tests. Th
 
 ```shell
 go test ./...
+```
+
+### Run Hugo server
+
+Build and serve the Hugo documentation site maintained in the `internal/docs` directory. This command will start the Hugo server and generate the documentation site, which can be accessed in a web browser.
+
+```shell
+hugo server -s internal/docs    # exclude drafts
+```
+
+```shell
+hugo server -s internal/docs -D # include drafts
 ```
 
 ### Run NPM tests


### PR DESCRIPTION
## Summary of Changes

Added instructions for building and running the Hugo documentation site in the monorepo.

## Benefits and Impact

These changes will enable developers to easily build and run the Hugo documentation site locally, which will improve the development and testing process. This will help ensure that documentation changes are accurate and complete before being deployed to users. There are no known negative impacts.

## Testing and Validation

These changes were tested locally by following the instructions in the README file. The Hugo site was successfully built and served using the provided commands.

## Screenshots or Examples

N/A

## Checklist

- [x] I have updated the relevant documentation, if necessary.
- [ ] I have added tests to cover my changes, if applicable.
- [x] All new and existing tests passed.
- [x] My changes do not generate new warnings or errors.

## Additional Information

N/A
