### PR TITLE
Changed Go GH Action WF config to use CMD job name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,8 +2,8 @@ name: Go
 on:
   push:
 jobs:
-  go:
-    name: Go
+  cmd:
+    name: CMD
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary of Changes

This pull request updates the name of the job in the `.github/workflows/go.yml` file from `Go` to `CMD`.

## Benefits and Impact

This change is a minor update to the GitHub actions workflow and does not have a significant impact on the project or its users.

## Testing and Validation

N/A

## Screenshots or Examples

N/A

## Checklist

> PROMPT: Check all that apply

- [ ] I have updated the relevant documentation, if necessary.
- [ ] I have added tests to cover my changes, if applicable.
- [ ] All new and existing tests passed.
- [x] My changes do not generate new warnings or errors.

## Additional Information

N/A
