### PR TITLE
Changes for clean-up

### DIFF
--- a/count.go
+++ b/count.go
@@ -1,5 +1,6 @@
 package nostr
 
+// Count TBD
 type Count struct {
-	Count uint32 `json:"count,omitempty"`
+	Count float64 `json:"count,omitempty"`
 }

--- a/event.go
+++ b/event.go
@@ -45,11 +45,6 @@ type Event interface {
 	Validate() error
 }
 
-// newBaseEvent TBD
-func newBaseEvent() Event {
-	return &BaseEvent{}
-}
-
 type BaseEvent struct {
 	ID        string    `json:"id,omitempty"`
 	PubKey    string    `json:"pub_key,omitempty"`

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -8,9 +8,9 @@ import (
 )
 
 func main() {
-	// NOTE: Create a new context for managing the lifetime of the main function
+	// NOTE: Create a new context for managing the lifetime of the main
+	// function
 	ctx := context.Background()
-
 	// NOTE: Initialize a struct containing all the service servers
 	sc := struct {
 		cl *http.Server
@@ -19,14 +19,12 @@ func main() {
 		cl: buildClientServer(),
 		rl: buildRelayServer(),
 	}
-
-	// NOTE: Create an error group to manage the concurrent execution of service servers
+	// NOTE: Create an error group to manage the concurrent execution of
+	// service servers
 	g, _ := errgroup.WithContext(ctx)
-
 	// NOTE: Add service server Serve functions to the error group
 	g.Go(sc.cl.ListenAndServe)
 	g.Go(sc.rl.ListenAndServe)
-
 	// NOTE: Wait for all service servers to complete or return an error
 	if err := g.Wait(); err != nil {
 		panic(err)

--- a/message_test.go
+++ b/message_test.go
@@ -292,3 +292,70 @@ func TestCloseMessage_Validate(t *testing.T) {
 		})
 	}
 }
+
+func Test_NewCountMessage(t *testing.T) {
+	type args struct {
+		subscriptionID string
+		count          *nostr.Count
+	}
+	tests := []struct {
+		name   string
+		args   args
+		expect *nostr.CountMessage
+	}{
+		{
+			name: "MUST create a new CountMessage with given subscription ID and count",
+			args: args{
+				subscriptionID: "subscription-id",
+				count:          &nostr.Count{Count: 10},
+			},
+			expect: &nostr.CountMessage{nostr.BaseMessage{string(nostr.MessageTypeCount), "subscription-id", &nostr.Count{Count: 10}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countMessage := nostr.NewCountMessage(tt.args.subscriptionID, tt.args.count)
+			if !reflect.DeepEqual(countMessage, tt.expect) {
+				t.Errorf("expected %v, got %v", tt.expect, countMessage)
+			}
+			t.Logf("got %+v", countMessage)
+		})
+	}
+}
+
+func TestCountMessage_Marshal(t *testing.T) {
+	type args struct {
+		subscriptionID string
+		count          *nostr.Count
+	}
+	tests := []struct {
+		name   string
+		args   args
+		expect []byte
+		err    error
+	}{
+		{
+			name: "MUST successfully marshal CountMessage to byte slice",
+			args: args{
+				subscriptionID: "subscription-id",
+				count:          &nostr.Count{Count: 10},
+			},
+			expect: []byte("[\"COUNT\",\"subscription-id\",{\"count\":10}]"),
+			err:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countMessage := nostr.NewCountMessage(tt.args.subscriptionID, tt.args.count)
+			data, err := countMessage.Marshal()
+			if (err != nil && tt.err == nil) && (err == nil && tt.err != nil) && (err.Error() != tt.err.Error()) {
+				t.Fatalf("expected error: %s, got error: %s", tt.err, err)
+				return
+			}
+			if !reflect.DeepEqual(data, tt.expect) {
+				t.Fatalf("expected: %s, got: %s", tt.expect, data)
+			}
+			t.Logf("got: %+s", data)
+		})
+	}
+}

--- a/nip.go
+++ b/nip.go
@@ -1,5 +1,6 @@
 package nostr
 
+// NIP TBD
 type NIP int64
 
 const (

--- a/relay.go
+++ b/relay.go
@@ -33,7 +33,7 @@ type Relay struct {
 	Description   string       `json:"description,omitempty"`
 	PubKey        string       `json:"pub_key,omitempty"`
 	Contact       string       `json:"contact,omitempty"`
-	SupportedNIPs []string     `json:"supported_nips,omitempty"`
+	SupportedNIPs []NIP        `json:"supported_nips,omitempty"`
 	Software      string       `json:"software,omitempty"`
 	Version       string       `json:"version,omitempty"`
 	Limitations   *Limitations `json:"limitations,omitempty"`

--- a/tag.go
+++ b/tag.go
@@ -42,16 +42,8 @@ const (
 // Tag TBD
 type Tag interface {
 	Marshal() ([]byte, error)
-	Type() TagType
 	Unmarshal(data []byte) error
-}
-
-func NewBaseTag(typ TagType, args ...interface{}) Tag {
-	tag := BaseTag([]interface{}{typ})
-	for _, arg := range args {
-		tag = append(tag, arg)
-	}
-	return tag
+	Validate() error
 }
 
 // BaseTag TBD
@@ -60,14 +52,6 @@ type BaseTag []interface{}
 // Marshal TBD
 func (t BaseTag) Marshal() ([]byte, error) {
 	return json.Marshal(t)
-}
-
-// Type TBD
-func (t BaseTag) Type() TagType {
-	if len(t) < 1 {
-		panic("not ok")
-	}
-	return t[0].(TagType)
 }
 
 // Unmarshal TBD

--- a/tag_test.go
+++ b/tag_test.go
@@ -24,15 +24,11 @@ func Test_NewAmountTag(t *testing.T) {
 			expect: &nostr.AmountTag{},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tag := nostr.NewAmountTag(tt.args.amount)
-			if tag.Type() != nostr.TagTypeAmount {
-				t.Errorf("incorrect tag type")
-			}
-			if tag.(*nostr.AmountTag).Amount() != tt.args.amount {
-				t.Errorf("incorrect amount")
+			if reflect.DeepEqual(tt.expect, tag) {
+				t.Fatalf("expected %v, got %v", tt.expect, tag)
 			}
 			t.Logf("%+v", tag)
 		})
@@ -43,7 +39,6 @@ func TestAmountTag_Marshal(t *testing.T) {
 	type fields struct {
 		amount float64
 	}
-
 	tests := []struct {
 		name   string
 		fields fields
@@ -57,16 +52,13 @@ func TestAmountTag_Marshal(t *testing.T) {
 			expect: []byte{},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			amountTag := nostr.NewAmountTag(tt.fields.amount)
-
 			data, err := amountTag.Marshal()
 			if err != nil {
 				t.Errorf("%+v", err)
 			}
-
 			t.Logf("%+v", data)
 		})
 	}
@@ -95,7 +87,6 @@ func TestAmountTag_Unmarshal(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			amountTag := &nostr.AmountTag{}


### PR DESCRIPTION
## Summary of Changes

- Added comments for Count and NIP types.
- Changed Count type from uint32 to float64.
- Removed the newBaseEvent function.
- Refactored main.go to improve readability.
- Added new test cases for CountMessage.
- Changed the SupportedNIPs field type in Relay struct from []string to []NIP.
- Removed Type method and NewBaseTag function from Tag interface.
- Updated tag_test.go to reflect changes.

## Benefits and Impact

These changes improve code readability, modify data types to better represent their intended use, and add additional test coverage for CountMessage functionality. This will make it easier for developers to work with the codebase and ensure its stability.

## Testing and Validation

New test cases were added for CountMessage in message_test.go, covering NewCountMessage and Marshal functions. Existing test cases were modified in tag_test.go to reflect the removal of the Type method and NewBaseTag function.

## Screenshots or Examples

N/A

## Checklist

- [ ] I have updated the relevant documentation, if necessary.
- [x] I have added tests to cover my changes, if applicable.
- [x] All new and existing tests passed.
- [ ] My changes do not generate new warnings or errors.

## Additional Information

N/A
